### PR TITLE
Highest income share

### DIFF
--- a/app/services/world_bank_service.rb
+++ b/app/services/world_bank_service.rb
@@ -11,7 +11,18 @@ class WorldBankService
   end
 
   def highest_income_share(code)
-    response = @connection.get("")
+    response = @connection.get("/countries/#{code}/indicators/SI.DST.10TH.10?date=2013:2016&format=json")
+    income_share = JSON.parse(response.body)
+  end
+
+  def fuel_exports(code)
+    response = @connection.get("/countries/#{code}/indicators/TX.VAL.FUEL.ZS.UN?date=2013:2016&format=json")
+    fuel_exports = JSON.parse(response.body)
+  end
+
+  def central_government_debt(code)
+    response = @connection.get("/countries/#{code}/indicators/GC.DOD.TOTL.GD.ZS?date=2013:2016&format=json")
+    central_government_debt = JSON.parse(response.body)
   end
 
 end

--- a/app/services/world_bank_service.rb
+++ b/app/services/world_bank_service.rb
@@ -10,4 +10,8 @@ class WorldBankService
     country = JSON.parse(response.body)
   end
 
+  def highest_income_share(code)
+    response = @connection.get("")
+  end
+
 end

--- a/db/sql/database_queries.sql
+++ b/db/sql/database_queries.sql
@@ -8,5 +8,12 @@ inner join years y on y.id = i.year_id
 order by c.name;
 
 #query by average by region
+select r.title, avg(i.economic_freedom_index) as avg_efi, avg(i.corruption_perception_index) as avg_cpi, y.year
+from regions r
+inner join countries c on r.id = c.region_id
+inner join indicators i on i.country_id = c.id
+inner join years y on y.id = i.year_id
+group by r.title, y.year
+order by r.title, y.year DESC;
 
-#query
+#EFI ranking for in a year

--- a/spec/services/world_bank_service_spec.rb
+++ b/spec/services/world_bank_service_spec.rb
@@ -16,4 +16,11 @@ describe WorldBankService do
     expect(country[1].first["longitude"]).to eq("-58.4173")
     expect(country[1].first["latitude"]).to eq("-34.6118")
   end
+
+  it "returns the income share held by highest 10% for 2016 - 2014 for a country" do
+    country_code = "arg"
+    income_share = @service.highest_income_share(code)
+
+    expect(income_share).to eq("")
+  end
 end

--- a/spec/services/world_bank_service_spec.rb
+++ b/spec/services/world_bank_service_spec.rb
@@ -18,9 +18,32 @@ describe WorldBankService do
   end
 
   it "returns the income share held by highest 10% for 2016 - 2014 for a country" do
-    country_code = "arg"
-    income_share = @service.highest_income_share(code)
+    country_code = "egy"
+    income_share = @service.highest_income_share(country_code)
 
-    expect(income_share).to eq("")
+    expect(income_share[1][0]["indicator"]["value"]).to eq("Income share held by highest 10%")
+    expect(income_share[1][0]["country"]["value"]).to eq("Egypt, Arab Rep.")
+    expect(income_share[1][0]["value"]).to eq(nil)
+    expect(income_share[1][0]["date"]).to eq("2016")
+  end
+
+  it "returns the fuel exports % of total merchandise exports" do
+    country_code = "ecu"
+    fuel_exports = @service.fuel_exports(country_code)
+
+    expect(fuel_exports[1][0]["indicator"]["value"]).to eq("Fuel exports (% of merchandise exports)")
+    expect(fuel_exports[1][0]["country"]["value"]).to eq("Ecuador")
+    expect(fuel_exports[1][0]["value"]).to eq(nil)
+    expect(fuel_exports[1][0]["date"]).to eq("2016")
+  end
+
+  it "returns the fuel exports % of total merchandise exports" do
+    country_code = "IND"
+    central_government_debt = @service.central_government_debt(country_code)
+
+    expect(central_government_debt[1][0]["indicator"]["value"]).to eq("Central government debt, total (% of GDP)")
+    expect(central_government_debt[1][0]["country"]["value"]).to eq("India")
+    expect(central_government_debt[1][0]["value"]).to eq(nil)
+    expect(central_government_debt[1][0]["date"]).to eq("2016")
   end
 end


### PR DESCRIPTION
Builds out WorldBank Indicator Queries
highest_income_share, fuel_exports, central_government_debt queries
for the years 2013-2016. There are many nil values for recent years. Less than ideal,
but the code works.